### PR TITLE
Fixes for ATAK plugin development

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This plugin for working with Kaoinc 1S device and implements core messenger func
 rustup target add armv7-linux-androideabi
 rustup target add i686-linux-android
 rustup target add aarch64-linux-android
+rustup target add x86_64-linux-android
 ```
 * Update local.properties file
 ```

--- a/kaonic-plugin/build.gradle
+++ b/kaonic-plugin/build.gradle
@@ -35,7 +35,7 @@ android {
 cargo {
     module = "./kaonic"
     libname = "kaonic"
-    targets = ["arm", "arm64", "x86"]
+    targets = ["arm", "arm64", "x86", "x86_64"]
     verbose
     profile = 'release'
     features {

--- a/kaonic-plugin/kaonic/Cargo.toml
+++ b/kaonic-plugin/kaonic/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1.0.140"
 rmp-serde = "1.3.0"
 
 # reticulum-rs isn't public yet
-reticulum = { path = "../../../reticulum-rs" }
+reticulum = { path = "../../../Reticulum-rs" }
 
 # Logging
 log = "0.4.26"

--- a/kaonic-plugin/kaonic/src/messenger.rs
+++ b/kaonic-plugin/kaonic/src/messenger.rs
@@ -586,6 +586,7 @@ async fn handle_in_data<T: Platform + Send + 'static>(
                     },
                     LinkEvent::Activated => {},
                     LinkEvent::Closed => {},
+                    LinkEvent::Proof(_) => {},
                 }
             },
             _ = cancel.cancelled() => {
@@ -622,6 +623,7 @@ async fn handle_out_data<T: Platform + Send + 'static>(
                     },
                     LinkEvent::Activated => {},
                     LinkEvent::Closed => {},
+                    LinkEvent::Proof(_) => {},
                 }
             },
             _ = cancel.cancelled() => {


### PR DESCRIPTION
I'm in the process of updating the ATAK plugin and needed to make a few minor updates to this repo

* Adds the x86_64 target for the native lib so I can test the plugin in the Android emulator
* Added `LinkEvent::Proof(_) => {}` so it compiles with the latest version of Reticulum-rs
* Changed the case of reticulum-rs in build.gradle to Reticulum-rs so it compiles correctly on my linux machine